### PR TITLE
use FIXED dimensions of vectors in whole document

### DIFF
--- a/site/en/guides/milvus_operation.md
+++ b/site/en/guides/milvus_operation.md
@@ -233,8 +233,8 @@ A segment is a data file that Milvus automatically creates by merging inserted v
 #### Search vectors in a partition
 
 ```python
-# create 5 vectors of 32-dimension
->>> q_records = [[random.random() for _ in range(dim)] for _ in range(5)]
+# create 5 vectors of 256-dimension
+>>> q_records = [[random.random() for _ in range(256)] for _ in range(5)]
 >>> milvus.search(collection_name='test01', query_records=q_records, top_k=1, partition_tags=['tag01'], params=search_param)
 ```
 


### PR DESCRIPTION
On line#45, collection `test01` is set to 256 dimension.
On line#142, vectors of 256 dimensions are inserted into `test01`
However, on line#227, docs are saying to create query vector of "32-dimension". This will surely run into error: (Status(code=7, message='The vector dimension must be equal to the collection dimension.').

Nearest neighbor search algorithms assume FIXED dimension of dataset, inserted feature vectors and query vectors.
So, as in my previous pull request, I have proposed to set 'dim' parameter in the top of docs, when collection was created. 
OR instead of using `dim`, writed down direct values of the dimensions which will match your coding style used in this page.